### PR TITLE
create wiki style link (issue #31)

### DIFF
--- a/lib/md.js
+++ b/lib/md.js
@@ -105,6 +105,50 @@ md.renderer.rules.math = function(tokens, idx) {
   }
 }
 
+// inline [[]] rule
+// [[...]]
+
+md.inline.ruler.before('autolink', 'wikilink', function(state, silent) {
+  if (!(state.src.startsWith('[[', state.pos)) ) return false
+  let content = null
+  let tag = ']]'
+  let end = -1
+  for (let i = state.pos + tag.length; i < state.src.length; i++) {
+    if (state.src[i] === '\\') {
+      i++
+    } else if (state.src.startsWith(tag, i)) {
+      end = i
+      break
+    }
+  }
+
+  if (end >= 0) {  //found ]]
+    content = state.src.slice(state.pos + tag.length, end)
+  } else {
+    return false
+  }
+
+  if (content && !silent) {
+    state.push({
+      type: 'wikilink',
+      content: content,
+      tag: tag
+    })
+    state.pos += (content.length + 2 * tag.length)
+    return true
+  }
+  return false
+})
+
+md.renderer.rules.wikilink = function(tokens, idx) {
+  let content = tokens[idx].content,
+      tag = tokens[idx].tag
+
+  if (!content) return
+  //<a href="xxx.md">home</a>
+  return '<a href="' + content +'.md">'+ content + '</a>'
+}
+
 // enable footnotes
 md.block.ruler.enable([
   'footnote'

--- a/test/test.md
+++ b/test/test.md
@@ -34,3 +34,13 @@ var y = 13
 - the local font family for **styles/katex.min.less** should be eg: **atom://markdown-preview-enhanced/styles/fonts/KaTeX_AMS-Regular.eot** instead of **fonts/blabla.eot**   
 see [this link](https://discuss.atom.io/t/how-do-i-load-google-fonts-into-my-editors-styles/8321/4)
 - Now support **2-way scroll sync!**
+
+[REQ:slug] Here the requirement title
+
+    Here the requirement text, with *bold*, a [link](https://google.com), and a list:
+
+    - one,
+    - two,
+    - three
+
+[[kkk]]

--- a/test/test.md
+++ b/test/test.md
@@ -35,12 +35,4 @@ var y = 13
 see [this link](https://discuss.atom.io/t/how-do-i-load-google-fonts-into-my-editors-styles/8321/4)
 - Now support **2-way scroll sync!**
 
-[REQ:slug] Here the requirement title
-
-    Here the requirement text, with *bold*, a [link](https://google.com), and a list:
-
-    - one,
-    - two,
-    - three
-
-[[kkk]]
+[[wikilink]]


### PR DESCRIPTION
A quick implementation for #31 , most of the code are copied & pasted from the existing math rule.

`[[file_name]]` will be rendered as '<a href="file_name.md">file_name</a>'