### PR TITLE
can customize Math rendering indicator for inline and display mode.

### DIFF
--- a/lib/mathjax-wrapper.js
+++ b/lib/mathjax-wrapper.js
@@ -2,7 +2,7 @@
 let path = require('path')
 
 module.exports = {
-  loadMathJax: function(document) {
+  loadMathJax: function(document, indicator) {
     if (typeof(MathJax) === 'undefined' || !MathJax ) {
       let script = document.createElement('script')
 
@@ -15,8 +15,8 @@ module.exports = {
           showMathMenu: false,
           messageStyle: 'none',
           tex2jax: {
-            inlineMath: [['$','$']],
-            displayMath: [['$$','$$']],
+            inlineMath: [[indicator.inline,indicator.inline]],
+            displayMath: [[indicator.block,indicator.block]],
             processEscapes: true,
             processEnvironments: true,
             preview: 'none',

--- a/lib/md.js
+++ b/lib/md.js
@@ -38,11 +38,11 @@ atom.config.observe('markdown-preview-enhanced.mathRenderingOption', (option)=> 
 })
 
 atom.config.observe('markdown-preview-enhanced.indicatorForMathRenderingInline', (indicator)=> {
-  mathRenderingIndicator.inline = indicator;
+  mathRenderingIndicator.inline = indicator
 })
 
 atom.config.observe('markdown-preview-enhanced.indicatorForMathRenderingBlock', (indicator)=> {
-  mathRenderingIndicator.block = indicator;
+  mathRenderingIndicator.block = indicator.replace('\\n','\n')
 })
 
 atom.config.observe('markdown-preview-enhanced.enableWikiLinkSyntax', (flag)=> {
@@ -67,11 +67,12 @@ let md = new remarkable(defaults)
 // $$...$$
 md.inline.ruler.before('autolink', 'math', function(state, silent) {
   if (!mathRenderingOption) return false
-  if (state.src[state.pos] !== mathRenderingIndicator.inline) return false
+  if (state.src.substr(state.pos, mathRenderingIndicator.inline.length) !== mathRenderingIndicator.inline) return false
 
   let content = null
   let tag = mathRenderingIndicator.inline
-  if (state.src.startsWith(mathRenderingIndicator.block, state.pos)) {
+  if (state.src.substr(state.pos, mathRenderingIndicator.block.length) === mathRenderingIndicator.block) {
+    state.src += '\n'
     tag = mathRenderingIndicator.block
   }
 
@@ -112,7 +113,7 @@ md.renderer.rules.math = function(tokens, idx) {
   if (mathRenderingOption === 'KaTeX') {
     try {
       return  katex.renderToString(content, {
-                displayMode: (tag === mathRenderingIndicator.block ? false : true)
+                displayMode: tag === mathRenderingIndicator.block
               })
     } catch (e) {
       return '<span style="color: #ee7f49; font-weight: 500;">{ parse error: ' + content + ' }</span>'

--- a/lib/md.js
+++ b/lib/md.js
@@ -15,6 +15,10 @@ let katex = require('katex'), // for katex
     mermaidAPI = require('mermaid/dist/mermaid').mermaidAPI,
     loadMathJax = require('./mathjax-wrapper.js').loadMathJax,
     mathRenderingOption = null,
+    mathRenderingIndicator = {
+      inline: '$',
+      block: '$$'
+    },
     enableWikiLinkSyntax = false
 
 mermaidAPI.initialize({
@@ -31,6 +35,14 @@ atom.config.observe('markdown-preview-enhanced.mathRenderingOption', (option)=> 
       loadMathJax(document)
     }
   }
+})
+
+atom.config.observe('markdown-preview-enhanced.indicatorForMathRenderingInline', (indicator)=> {
+  mathRenderingIndicator.inline = indicator;
+})
+
+atom.config.observe('markdown-preview-enhanced.indicatorForMathRenderingBlock', (indicator)=> {
+  mathRenderingIndicator.block = indicator;
 })
 
 atom.config.observe('markdown-preview-enhanced.enableWikiLinkSyntax', (flag)=> {
@@ -55,12 +67,12 @@ let md = new remarkable(defaults)
 // $$...$$
 md.inline.ruler.before('autolink', 'math', function(state, silent) {
   if (!mathRenderingOption) return false
-  if (state.src[state.pos] !== '$') return false
+  if (state.src[state.pos] !== mathRenderingIndicator.inline) return false
 
   let content = null
-  let tag = '$'
-  if (state.src.startsWith('$$', state.pos)) {
-    tag = '$$'
+  let tag = mathRenderingIndicator.inline
+  if (state.src.startsWith(mathRenderingIndicator.block, state.pos)) {
+    tag = mathRenderingIndicator.block
   }
 
   let end = -1
@@ -100,7 +112,7 @@ md.renderer.rules.math = function(tokens, idx) {
   if (mathRenderingOption === 'KaTeX') {
     try {
       return  katex.renderToString(content, {
-                displayMode: (tag === '$' ? false : true)
+                displayMode: (tag === mathRenderingIndicator.block ? false : true)
               })
     } catch (e) {
       return '<span style="color: #ee7f49; font-weight: 500;">{ parse error: ' + content + ' }</span>'

--- a/lib/md.js
+++ b/lib/md.js
@@ -32,7 +32,7 @@ atom.config.observe('markdown-preview-enhanced.mathRenderingOption', (option)=> 
     mathRenderingOption = option
 
     if (mathRenderingOption[0] === 'M') { // MathJax
-      loadMathJax(document)
+      loadMathJax(document, mathRenderingIndicator)
     }
   }
 })

--- a/package.json
+++ b/package.json
@@ -39,6 +39,20 @@
       ],
       "order": 20
     },
+    "indicatorForMathRenderingInline": {
+      "title": "Inline Indicator",
+      "type": "string",
+      "default": "$",
+      "description": "Use customized Math expression inline indicator. By default it is $",
+      "order": 21
+    },
+    "indicatorForMathRenderingBlock": {
+      "title": "Block Indicator",
+      "type": "string",
+      "default": "$$",
+      "description": "Use customized Math expression block indicator. By default it is $$",
+      "order": 22
+    },
     "enableWikiLinkSyntax": {
       "title": "Enable Wiki Link syntax",
       "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
       "title": "Block Indicator",
       "type": "string",
       "default": "$$",
-      "description": "Use customized Math expression block indicator. By default it is $$",
+      "description": "Use customized Math expression block indicator(\\n as newline character). By default it is $$",
       "order": 22
     },
     "enableWikiLinkSyntax": {


### PR DESCRIPTION
<img width="790" alt="screen shot 2016-06-06 at 5 09 16 pm" src="https://cloud.githubusercontent.com/assets/11534233/15817479/bede6ee4-2c0a-11e6-8eab-bad508566533.png">

I think it is a useful feature that writer can customize Math rendering indicator for inline and display mode since there are some platforms within abnormal indicator for MathJax or KaTeX such as GitBook.

It is inspired by a Chrome extension [TeX All the Things](https://chrome.google.com/webstore/detail/tex-all-the-things/cbimabofgmfdkicghcadidpemeenbffn?hl=en-US)

![screen shot 2016-06-06 at 5 23 44 pm](https://cloud.githubusercontent.com/assets/11534233/15817667/b937f16c-2c0b-11e6-80bc-f9b1c0717226.png)
