### PR TITLE
Improve icons in upper right toolbar of preview

### DIFF
--- a/lib/markdown-preview-enhanced-view.coffee
+++ b/lib/markdown-preview-enhanced-view.coffee
@@ -629,7 +629,7 @@ class MarkdownPreviewEnhancedView extends ScrollView
     backToTopBtn = document.createElement('div')
     backToTopBtn.classList.add('back-to-top-btn')
     backToTopBtn.classList.add('btn')
-    backToTopBtn.innerHTML = '<span>⭱</span>'
+    backToTopBtn.innerHTML = '<span>⬆︎</span>'
     @toolbar.appendChild(backToTopBtn)
 
     backToTopBtn.onclick = ()=>

--- a/lib/markdown-preview-enhanced-view.coffee
+++ b/lib/markdown-preview-enhanced-view.coffee
@@ -629,7 +629,7 @@ class MarkdownPreviewEnhancedView extends ScrollView
     backToTopBtn = document.createElement('div')
     backToTopBtn.classList.add('back-to-top-btn')
     backToTopBtn.classList.add('btn')
-    backToTopBtn.innerHTML = '<span>⬆︎</span>'
+    backToTopBtn.innerHTML = '<span>⭱</span>'
     @toolbar.appendChild(backToTopBtn)
 
     backToTopBtn.onclick = ()=>
@@ -648,7 +648,7 @@ class MarkdownPreviewEnhancedView extends ScrollView
     sidebarTOCBtn = document.createElement('div')
     sidebarTOCBtn.classList.add('sidebar-toc-btn')
     sidebarTOCBtn.classList.add('btn')
-    sidebarTOCBtn.innerHTML = '<span>≡</span>'
+    sidebarTOCBtn.innerHTML = '<span>§</span>'
     @toolbar.appendChild(sidebarTOCBtn)
 
     helper = ()=>

--- a/lib/style-template.coffee
+++ b/lib/style-template.coffee
@@ -40,6 +40,7 @@ module.exports = """
       width: 32px;
       margin-right: 4px;
       opacity: 0.4;
+      font-size: 20px;
 
       &:hover {
         opacity: 1.0;


### PR DESCRIPTION
The icons in this package have a few problems:

- They're tiny, almost unreadable
- The hamburger icon (≡) is misleading; usually this is a general purpose dropdown menu, so users might click it expecting to see a menu of various options for the preview (I did), and be surprised when the table of contents appears instead (I was)
- The up arrow isn't as clear as it could be. It scrolls to the top, but an up arrow can mean many things.

This pull request tries to address these issues:

- Increase font size so they're visible
- Replace hamburger icon with section icon, a symbol used in outlines
- Replace thick up arrow with up arrow pointing at bar, the bar representing the top of the document

![markdown-preview-enhanced-buttons](https://user-images.githubusercontent.com/1559108/27317998-8ca11156-554f-11e7-82dd-771f83e4636c.png)
