### PR TITLE
Update atom-typings and fix breakages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/jquery": "^3.2.7",
     "@types/mocha": "^2.2.41",
     "@types/node": "^8.0.11",
-    "atom-typings": "^1.18.1",
+    "atom-typings": "^1.20.1",
     "chinese-conv": "^1.0.1",
     "typescript": "^2.4.1"
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,4 @@
 import {MarkdownEngineConfig} from "@shd101wyy/mume"
-import {CompositeDisposable} from "atom"
 
 export class MarkdownPreviewEnhancedConfig implements MarkdownEngineConfig {
   public static getCurrentConfig() {
@@ -101,7 +100,7 @@ export class MarkdownPreviewEnhancedConfig implements MarkdownEngineConfig {
     this.imageUploader = atom.config.get('markdown-preview-enhanced.imageUploader')
   }
 
-  public onDidChange(subscriptions:CompositeDisposable, callback) {
+  public onDidChange(subscriptions:Atom.CompositeDisposable, callback) {
     subscriptions.add(
       atom.config.onDidChange('markdown-preview-enhanced.usePandocParser', ({newValue})=> {
         this.usePandocParser = newValue

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ const utility = mume.utility
 import {MarkdownPreviewEnhancedConfig} from "./config"
 import {MarkdownPreviewEnhancedView} from "./preview-content-provider"
 
-let subscriptions:CompositeDisposable = null
+let subscriptions:Atom.CompositeDisposable = null
 let config:MarkdownPreviewEnhancedConfig = null
 
 /**
@@ -179,7 +179,7 @@ mume.init() // init mume package
       if (!preview) return
 
       if (config.singlePreview && preview.getEditor() !== editor) {
-        preview.bindEditor(editor as AtomCore.TextEditor)
+        preview.bindEditor(editor as Atom.TextEditor)
       }
 
       if (config.automaticallyShowPreviewOfMarkdownBeingEdited) {
@@ -442,7 +442,7 @@ function showUploadedImages() {
  * @param filePath 
  */
 async function onModifySource(codeChunkData, result, filePath) {
-  function insertResult(i:number, editor:AtomCore.TextEditor, lines:string[]) {
+  function insertResult(i:number, editor:Atom.TextEditor, lines:string[]) {
     const lineCount = editor.getLineCount()
     let start = 0
     // find <!- code_chunk_output --> 
@@ -490,7 +490,7 @@ async function onModifySource(codeChunkData, result, filePath) {
 
   const visibleTextEditors = atom.workspace.getTextEditors()
   for (let i = 0; i < visibleTextEditors.length; i++) {
-    const editor = visibleTextEditors[i] as AtomCore.TextEditor
+    const editor = visibleTextEditors[i] as Atom.TextEditor
     if (editor.getPath() === filePath) {
       let codeChunkOffset = 0,
           targetCodeChunkOffset = codeChunkData.options['code_chunk_offset']

--- a/src/preview-content-provider.ts
+++ b/src/preview-content-provider.ts
@@ -26,12 +26,12 @@ export class MarkdownPreviewEnhancedView {
   private element: HTMLDivElement = null
   private webview = null
   private uri: string = ''
-  private disposables: CompositeDisposable = null
+  private disposables: Atom.CompositeDisposable = null
 
   /**
    * The editor binded to this preview.
    */
-  private editor:AtomCore.TextEditor = null
+  private editor:Atom.TextEditor = null
   /**
    * Configs.
    */
@@ -133,7 +133,7 @@ export class MarkdownPreviewEnhancedView {
    * Bind editor to preview
    * @param editor
    */
-  public bindEditor(editor:AtomCore.TextEditor) {
+  public bindEditor(editor:Atom.TextEditor) {
     if (!this.editor) {
       this.editor = editor // this has to be put here, otherwise the tab title will be `unknown`
       atom.workspace.open(this.uri, {
@@ -814,7 +814,7 @@ export class MarkdownPreviewEnhancedView {
     })
   }
 
-  private static replaceHint(editor: AtomCore.TextEditor, bufferRow:number, hint:string, withStr:string):boolean {
+  private static replaceHint(editor: Atom.TextEditor, bufferRow:number, hint:string, withStr:string):boolean {
     if (!editor) return false
     const lines = editor.buffer.getLines()
     let textLine = lines[bufferRow] || ''
@@ -828,7 +828,7 @@ export class MarkdownPreviewEnhancedView {
     return false
   }
 
-  private static setUploadedImageURL(editor: AtomCore.TextEditor, imageFileName:string, url:string, hint:string, bufferRow:number) {
+  private static setUploadedImageURL(editor: Atom.TextEditor, imageFileName:string, url:string, hint:string, bufferRow:number) {
     let description
     if (imageFileName.lastIndexOf('.'))
       description = imageFileName.slice(0, imageFileName.lastIndexOf('.'))
@@ -852,7 +852,7 @@ export class MarkdownPreviewEnhancedView {
    * Then insert markdown image url to markdown file.
    * @param imageFilePath
    */
-  public static uploadImageFile(editor:AtomCore.TextEditor, imageFilePath:string, imageUploader:string="imgur") {
+  public static uploadImageFile(editor:Atom.TextEditor, imageFilePath:string, imageUploader:string="imgur") {
     if (!editor) return
 
     const imageFileName = path.basename(imageFilePath)


### PR DESCRIPTION
Recent updates to atom-typings have broken a few type references in your package, with this pull request fixing them. The changes within atom-typings were:

- the merger to all namespaces into the singular "Atom" namespace
- the use of interfaces over classes

The overall layout of atom-typings wont change anymore, with updates from here onward only providing definition fixes and Atom API updates.