### PR TITLE
Fix link to "Embed LaTeX, render TikZ, Chemfig etc" in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ Post [here](https://github.com/shd101wyy/markdown-preview-enhanced/issues) if yo
 - [Customize Preview CSS](customize-css.md)
 - [TOC](toc.md) generation
 - [Flowchart / Sequence diagram and many other kinds of graphs](diagrams.md)
-- [Embed LaTeX, render TikZ, Chemfig
+- [Embed LaTeX, render TikZ, Chemfig etc](code-chunk.md?id=latex)
 - Task List *(Github Flavored)*
 - Image Helper
 - [Footnotes](https://github.com/shd101wyy/markdown-preview-enhanced/issues/35)


### PR DESCRIPTION
Reverts https://github.com/shd101wyy/markdown-preview-enhanced/commit/027e0c1904f2257401d8b68d6613357d6d962168#diff-e70100059cc3a7376740bbe9751a082eR33