### PR TITLE
';' cause syntax error.

### DIFF
--- a/docs/zh-cn/diagrams.md
+++ b/docs/zh-cn/diagrams.md
@@ -97,7 +97,7 @@ blockdiag {
     { name: "Request", wave: "0.1..0|1.0" },
     {},
     { name: "Acknowledge", wave: "1.....|01." },
-  ];
+  ]
 }
 ```
 ````


### PR DESCRIPTION
';' cause syntax error.
See:
```
Error 400: SyntaxError: JSON5: invalid character ';' at 12:4 at syntaxError (/snapshot/app/node_modules/json5/lib/parse.js:1110:17) at invalidChar (/snapshot/app/node_modules/json5/lib/parse.js:1055:12) at Object.afterPropertyValue (/snapshot/app/node_modules/json5/lib/parse.js:676:15) at Object.default (/snapshot/app/node_modules/json5/lib/parse.js:168:37) at lex (/snapshot/app/node_modules/json5/lib/parse.js:100:42) at Object.parse (/snapshot/app/node_modules/json5/lib/parse.js:25:17) at convert (/snapshot/app/index.js:20:24) at Socket. (/snapshot/app/index.js:58:13) at Socket.emit (node:events:549:35) at endReadableNT (node:internal/streams/readable:1359:12) { lineNumber: 12, columnNumber: 4 } (exit code 1)
```