### PR TITLE
Add Documentation for `registerIconPacks` in mermaid section (English / Japanese)

### DIFF
--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -22,6 +22,32 @@ Three mermaid themes are provided, and you can choose theme from [package settin
 
 You can also edit the mermaid init config by running `Markdown Preview Enhanced: Open Mermaid Config` command.
 
+Moreover, you can register icon logos in head.html (opened via `Markdown Preview Enhanced: Customize Preview Html Head` command) as follows:
+
+```html
+<script type="text/javascript">
+  const configureMermaidIconPacks = () => {
+    window["mermaid"].registerIconPacks([
+      {
+        name: "logos",
+        loader: () =>
+          fetch("https://unpkg.com/@iconify-json/logos/icons.json").then(
+            (res) => res.json()
+          ),
+      },
+    ]);
+  };
+
+  if (document.readyState !== 'loading') {
+    configureMermaidIconPacks();
+  } else {
+    document.addEventListener("DOMContentLoaded", () => {
+      configureMermaidIconPacks();
+    });
+  }
+</script>
+```
+
 ## PlantUML
 
 Markdown Preview Enhanced uses [PlantUML](https://plantuml.com/) to create multiple kinds of graph. (**Java** is required to be installed)

--- a/docs/ja-jp/diagrams.md
+++ b/docs/ja-jp/diagrams.md
@@ -22,6 +22,32 @@ Markdown Preview Enhanced は、[mermaid](https://github.com/knsv/mermaid) を�
 
 `Markdown Preview Enhanced：Open Mermaid Config` コマンドを実行して、`mermaid` の初期設定を編集することもできます。
 
+また、ロゴを登録することもできます。`Markdown Preview Enhanced: Customize Preview Html Head`で開く head.html ファイル内に、次のコードを追加することで実現できます。
+
+```html
+<script type="text/javascript">
+  const configureMermaidIconPacks = () => {
+    window["mermaid"].registerIconPacks([
+      {
+        name: "logos",
+        loader: () =>
+          fetch("https://unpkg.com/@iconify-json/logos/icons.json").then(
+            (res) => res.json()
+          ),
+      },
+    ]);
+  };
+
+  if (document.readyState !== 'loading') {
+    configureMermaidIconPacks();
+  } else {
+    document.addEventListener("DOMContentLoaded", () => {
+      configureMermaidIconPacks();
+    });
+  }
+</script>
+```
+
 ## PlantUML
 
 Markdown Preview Enhanced は、[PlantUML](https://plantuml.com/) を使用して複数の種類のグラフを作成します。(**Java** のインストールが必要です)

--- a/docs/ko-kr/diagrams.md
+++ b/docs/ko-kr/diagrams.md
@@ -20,6 +20,31 @@ Markdown Preview Enhanced는 [mermaid](https://github.com/knsv/mermaid) 를 사�
   ![screen shot 2017-06-05 at 8 47 00 pm](https://cloud.githubusercontent.com/assets/1908863/26810274/555562d0-4a30-11e7-91ca-98742d6afbd5.png)
 
 또한 `Markdown Preview Enhanced: Open Mermaid Config` 명령을 실행하여 mermaid의 초기 설정을 편집할 수도 있다.
+또한 Markdown Preview Enhanced: Customize Preview Html Head 명령을 통해 열리는 head.html에서 아이콘 로고를 다음과 같이 등록할 수 있습니다:
+
+```html
+<script type="text/javascript">
+  const configureMermaidIconPacks = () => {
+    window["mermaid"].registerIconPacks([
+      {
+        name: "logos",
+        loader: () =>
+          fetch("https://unpkg.com/@iconify-json/logos/icons.json").then(
+            (res) => res.json()
+          ),
+      },
+    ]);
+  };
+
+  if (document.readyState !== 'loading') {
+    configureMermaidIconPacks();
+  } else {
+    document.addEventListener("DOMContentLoaded", () => {
+      configureMermaidIconPacks();
+    });
+  }
+</script>
+```
 
 ## PlantUML
 

--- a/docs/zh-cn/diagrams.md
+++ b/docs/zh-cn/diagrams.md
@@ -22,6 +22,32 @@ Markdown Preview Enhanced 使用 [mermaid](https://github.com/knsv/mermaid) 来�
 
 你还可以通过 `Markdown Preview Enhanced: Open Mermaid Config` 命令打开 mermaid 配置文件。
 
+此外，您可以在 head.html 中注册图标标志（通过 Markdown Preview Enhanced: Customize Preview Html Head 命令打开），如下所示：
+
+```html
+<script type="text/javascript">
+  const configureMermaidIconPacks = () => {
+    window["mermaid"].registerIconPacks([
+      {
+        name: "logos",
+        loader: () =>
+          fetch("https://unpkg.com/@iconify-json/logos/icons.json").then(
+            (res) => res.json()
+          ),
+      },
+    ]);
+  };
+
+  if (document.readyState !== 'loading') {
+    configureMermaidIconPacks();
+  } else {
+    document.addEventListener("DOMContentLoaded", () => {
+      configureMermaidIconPacks();
+    });
+  }
+</script>
+```
+
 ## PlantUML
 
 Markdown Preview Enhanced 使用 [PlantUML](https://plantuml.com/) 来创建各种图形。（**Java** 是需要先被安装好的）

--- a/docs/zh-tw/diagrams.md
+++ b/docs/zh-tw/diagrams.md
@@ -22,6 +22,32 @@ Markdown Preview Enhanced 使用 [mermaid](https://github.com/knsv/mermaid) 來�
 
 你還可以通過 `Markdown Preview Enhanced: Open Mermaid Config` 命令打開 mermaid 配置文件。
 
+此外，您可以在 head.html 中註冊圖標標誌（通過 Markdown Preview Enhanced: Customize Preview Html Head 命令打開），如下所示：
+
+```html
+<script type="text/javascript">
+  const configureMermaidIconPacks = () => {
+    window["mermaid"].registerIconPacks([
+      {
+        name: "logos",
+        loader: () =>
+          fetch("https://unpkg.com/@iconify-json/logos/icons.json").then(
+            (res) => res.json()
+          ),
+      },
+    ]);
+  };
+
+  if (document.readyState !== 'loading') {
+    configureMermaidIconPacks();
+  } else {
+    document.addEventListener("DOMContentLoaded", () => {
+      configureMermaidIconPacks();
+    });
+  }
+</script>
+```
+
 ## PlantUML
 
 Markdown Preview Enhanced 使用 [PlantUML](https://plantuml.com/) 來創建各種圖形。（**Java** 是需要先被安裝好的）


### PR DESCRIPTION
Hi @shd101wyy

This PR relates https://github.com/shd101wyy/crossnote/issues/361 .

# What I did

- I added description for loading logos in mermaid in English / Japanese doc.

# What I did not

- other language doc suppport